### PR TITLE
Add new post script

### DIFF
--- a/new_post.py
+++ b/new_post.py
@@ -1,0 +1,38 @@
+import sys
+from datetime import datetime
+
+TEMPLATE = """
+Title: {title}
+Date: {year}-{month}-{day} {hour}:{minute:02d}
+Modified: 
+Author: 
+Category: 
+Tags: 
+
+
+
+"""
+
+
+def make_entry(title):
+    today = datetime.today()
+    title_no_whitespaces = title.lower().strip().replace(' ', '-')
+    f_create = "content/{}_{:0>2}_{:0>2}_{}.md".format(
+        today.year, today.month, today.day, title_no_whitespaces)
+    t = TEMPLATE.strip().format(title=title,
+                                year=today.year,
+                                month=today.month,
+                                day=today.day,
+                                hour=today.hour,
+                                minute=today.minute)
+    with open(f_create, 'w') as w:
+        w.write(t)
+    print("File created -> " + f_create)
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) > 1:
+        make_entry(sys.argv[1])
+    else:
+        print "No title given"


### PR DESCRIPTION
This is a possible solution for issue #8. Found this script and modified it for us to use and create a new blog post. The user will need to call the script and pass the title of the blog post as shown below and a file will be created in the /content folder with the filename format YYYY_MM_DD_new-post-title.md.

`python new_post.py "New Post Title"`

Inside the file created will be the basic structure for a new markdown post

```
Title: New Post Title
Date: YYYY-MM-DD HH:MM
Modified: 
Author: 
Category: 
Tags: 
```
