### PR TITLE
Create initial contributor page

### DIFF
--- a/content/pages/contributors.md
+++ b/content/pages/contributors.md
@@ -1,0 +1,24 @@
+Title: Contributors
+Date: 2016-11-02
+
+Python Monthly is a group of people coming together to learn and challenge themselves using the Python programming language.
+
+Key Members:
+
+Jay Miller  
+Email: kjaymiller@gmail.com
+
+Kenneth Love  
+Email: kennethlove@gmail.com
+
+Mallory Hancock  
+Email: malloryhancock89@gmail.com
+
+Andy Culler
+Email: adc4392@gmail.com
+
+Daniel Kaczmarczyk
+Email: danielkaczmarczyk2@gmail.com
+
+TJ Nel
+Email: mikiozen@gmail.com


### PR DESCRIPTION
Creates a simple page that should have the information of who is
working on this project.